### PR TITLE
Fixing display of roll templates in dark mode

### DIFF
--- a/lib/dcc_tabbed_sheet/version.rb
+++ b/lib/dcc_tabbed_sheet/version.rb
@@ -1,4 +1,4 @@
 module DccTabbedSheet
   VERSION = "0.1.0"
-  SHEET_VERSION = "1.6.1"
+  SHEET_VERSION = "1.6.2"
 end

--- a/views/DCC_Tabbed_Sheet.css.erb
+++ b/views/DCC_Tabbed_Sheet.css.erb
@@ -4380,7 +4380,7 @@ div[data-groupname^="repeating_mutations"] .repitem,
 /* Handle Dark Mode */
 .sheet-rolltemplate-darkmode .sheet-RollTemp-wrapper {
   background-color: white;
-  color: black;
+  color: #404040;
 }
 
 .sheet-rolltemplate-darkmode .inlinerollresult {

--- a/views/DCC_Tabbed_Sheet.css.erb
+++ b/views/DCC_Tabbed_Sheet.css.erb
@@ -4377,4 +4377,26 @@ div[data-groupname^="repeating_mutations"] .repitem,
     max-width: 100%;
 }
 
+/* Handle Dark Mode */
+.sheet-rolltemplate-darkmode .sheet-RollTemp-wrapper {
+  background-color: white;
+}
+
+.sheet-rolltemplate-darkmode .inlinerollresult {
+  background-color: #fef68e !important;
+  border: 2px solid #fef68e !important;
+}
+
+.sheet-rolltemplate-darkmode .inlinerollresult.fullcrit {
+  border: 2px solid #3fb315 !important;
+}
+
+.sheet-rolltemplate-darkmode .inlinerollresult.fullfail {
+  border: 2px solid #b31515 !important;
+}
+
+.sheet-rolltemplate-darkmode .inlinerollresult.importantroll {
+  border: 2px solid #4a57ed !important;
+}
+
 /* End custom Pure grid css (24 cols) */

--- a/views/DCC_Tabbed_Sheet.css.erb
+++ b/views/DCC_Tabbed_Sheet.css.erb
@@ -4380,6 +4380,7 @@ div[data-groupname^="repeating_mutations"] .repitem,
 /* Handle Dark Mode */
 .sheet-rolltemplate-darkmode .sheet-RollTemp-wrapper {
   background-color: white;
+  color: black;
 }
 
 .sheet-rolltemplate-darkmode .inlinerollresult {

--- a/views/ReadMe.erb
+++ b/views/ReadMe.erb
@@ -16,6 +16,9 @@ You can follow development here: https://trello.com/b/jfLKA3e6/dcc-tabbed-sheet-
 
 ### Changelog
 
+#### 1.6.2
+* Bug fix: Fixed display of roll templates in dark mode
+
 #### 1.6.1
 
 * Bug fix: Fixed issue where some level0 characters' rolls weren't being shown correctly (Thanks GrapeApe!)


### PR DESCRIPTION
Addressing https://github.com/rgould/dcc_tabbed_sheet/issues/3

This fixes the display of roll templates in dark mode. The base Roll20 dark mode CSS is still overriding plenty of what's set in the sheet's CSS, but this at least restores the background and roll result colors.

Before Light:
![LightMode](https://user-images.githubusercontent.com/242696/184559403-dc392eb3-0476-4eae-84c4-ccd0df5110b1.jpg)

After Light:
![LightMode-New](https://user-images.githubusercontent.com/242696/184559406-b5e5261a-008c-46e4-81a6-210de666eac5.jpg)

Before Dark:
![DarkMode](https://user-images.githubusercontent.com/242696/184559409-32c4bb86-9479-44ac-bb3e-4681910bf5ea.jpg)

After Dark:
![DarkMode-New](https://user-images.githubusercontent.com/242696/184559412-80875029-1974-4f90-a65a-394b4f6c9630.jpg)

